### PR TITLE
Added functionality for creating new assets and sending them to a distribution account

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,8 +2,11 @@ import React, { useState } from 'react';
 import './App.css';
 import Home from './pages/Home';
 import SubmitTransaction from './components/SubmitTransaction';
+import IssueNewAsset from './components/IssueNewAsset';
 
 function App() {
+  const issuerAccountPrivateKey = 'SBNJMFBUVROLXVHVZUK3SXXB5I6MN3AUJSUX5WCTQN6WBEDDZPF7DDJZ';
+  const distributorAccountPrivateKey = 'SDZGGESB5BZBV2E6W4SOSZZ4P2H7N5P2MA6Z6CQNVUGDXNGYQQV5FVJR';
   const [borrowerAccount, setBorrowerAccount] = useState('');
   const [submitTransactionClicked, setSubmitTransactionClicked] = useState(false);
   return (
@@ -13,10 +16,17 @@ function App() {
         borrowerAccount={borrowerAccount}
         setSubmitTransactionClicked={setSubmitTransactionClicked}
       ></Home>
+
       <SubmitTransaction
         borrowerAccount={borrowerAccount}
         submitTransactionClicked={submitTransactionClicked}
         setSubmitTransactionClicked={setSubmitTransactionClicked}
+        issuerAccountPrivateKey={issuerAccountPrivateKey}
+      />
+
+      <IssueNewAsset
+        issuerAccountPrivateKey={issuerAccountPrivateKey}
+        distributorAccountPrivateKey={distributorAccountPrivateKey}
       />
     </div>
   );

--- a/src/components/IssueNewAsset.js
+++ b/src/components/IssueNewAsset.js
@@ -1,0 +1,86 @@
+import { useEffect } from 'react';
+const StellarSdk = require('stellar-sdk');
+const IssueNewAsset = (props) => {
+  const issuerAccountPrivateKey = props.issuerAccountPrivateKey;
+  const distributorAccountPrivateKey = props.distributorAccountPrivateKey;
+
+  // Keys for accounts to issue and receive the new asset
+  const issuingKeys = StellarSdk.Keypair.fromSecret(issuerAccountPrivateKey);
+  const receivingKeys = StellarSdk.Keypair.fromSecret(distributorAccountPrivateKey);
+
+  useEffect(() => {
+    const server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
+
+    // Create an object to represent the new asset
+    const USD = new StellarSdk.Asset('USD', issuingKeys.publicKey());
+    const WNT = new StellarSdk.Asset('WNT', issuingKeys.publicKey());
+
+    // First, the receiving account must trust the asset
+    server
+      .loadAccount(receivingKeys.publicKey())
+      .then(function (receiver) {
+        const transaction = new StellarSdk.TransactionBuilder(receiver, {
+          fee: 100,
+          networkPassphrase: StellarSdk.Networks.TESTNET,
+        })
+          // The `changeTrust` operation creates (or alters) a trustline
+          // The `limit` parameter below is optional
+          .addOperation(
+            StellarSdk.Operation.changeTrust({
+              asset: USD,
+            })
+          )
+          // setTimeout is required for a transaction
+          .addOperation(
+            StellarSdk.Operation.changeTrust({
+              asset: WNT,
+            })
+          )
+          // setTimeout is required for a transaction
+          .setTimeout(100)
+          .build();
+        transaction.sign(receivingKeys);
+        return server.submitTransaction(transaction);
+      })
+      .then(console.log)
+
+      // Second, the issuing account actually sends a payment using the asset
+      .then(function () {
+        return server.loadAccount(issuingKeys.publicKey());
+      })
+      .then(function (issuer) {
+        const transaction = new StellarSdk.TransactionBuilder(issuer, {
+          fee: 100,
+          networkPassphrase: StellarSdk.Networks.TESTNET,
+        })
+          .addOperation(
+            StellarSdk.Operation.payment({
+              destination: receivingKeys.publicKey(),
+              asset: USD,
+              amount: '10000',
+            })
+          )
+          // setTimeout is required for a transaction
+          .addOperation(
+            StellarSdk.Operation.payment({
+              destination: receivingKeys.publicKey(),
+              asset: WNT,
+              amount: '10000',
+            })
+          )
+          // setTimeout is required for a transaction
+          .setTimeout(100)
+          .build();
+        transaction.sign(issuingKeys);
+        return server.submitTransaction(transaction);
+      })
+      .then(console.log)
+      .catch(function (error) {
+        console.error('Error!', error);
+      });
+  }, [issuingKeys, receivingKeys]);
+
+  return null;
+};
+
+export default IssueNewAsset;

--- a/src/components/SubmitTransaction.js
+++ b/src/components/SubmitTransaction.js
@@ -2,22 +2,25 @@ import { useEffect } from 'react';
 const StellarSdk = require('stellar-sdk');
 
 const server = new StellarSdk.Server('https://horizon-testnet.stellar.org');
-const emitterAccountPublicKey = 'GBJDIEEJ4HUXQSYNINVBAJ35FLSUGFFVLPBHVI65R42GUDKIMJ7PKHGJ';
-const emitterAccountPrivateKey = 'SBJYCFTUCM5GLIZNXRO5T7HTEY2IILMP2GHUTXQMDIAMRCF25U333PCF';
 
 const SubmitTransaction = (props) => {
+  const issuerAccountPrivateKey = props.issuerAccountPrivateKey;
   const borrowerAccount = props.borrowerAccount;
-  const submitTransactionClicked = props.submitTransactionClicked;
-  const setSubmitTransactionClicked = props.setSubmitTransactionClicked;
+  const submitTransactionIsClicked = props.submitTransactionIsClicked;
+  const setSubmitTransactionIsClicked = props.setSubmitTransactionIsClicked;
+
+  // Derive Keypair object and public key (that starts with a G) from the secret
+  const sourceKeypair = StellarSdk.Keypair.fromSecret(issuerAccountPrivateKey);
+  const issuerAccountPublicKey = sourceKeypair.publicKey();
   useEffect(() => {
     if (
       borrowerAccount.length === 56 &&
       borrowerAccount.charAt(0) === 'G' &&
-      submitTransactionClicked === true
+      submitTransactionIsClicked === true
     ) {
-      setSubmitTransactionClicked(false);
+      setSubmitTransactionIsClicked(false);
       async function SubmitTransactionAsync() {
-        const account = await server.loadAccount(emitterAccountPublicKey);
+        const account = await server.loadAccount(issuerAccountPublicKey);
 
         /*
         Right now, we have one function that fetches the base fee.
@@ -42,7 +45,7 @@ const SubmitTransaction = (props) => {
           .build();
 
         // sign the transaction
-        transaction.sign(StellarSdk.Keypair.fromSecret(emitterAccountPrivateKey));
+        transaction.sign(StellarSdk.Keypair.fromSecret(issuerAccountPrivateKey));
 
         try {
           const transactionResult = await server.submitTransaction(transaction);
@@ -55,7 +58,13 @@ const SubmitTransaction = (props) => {
     } else {
       return null;
     }
-  }, [borrowerAccount, setSubmitTransactionClicked, submitTransactionClicked]);
+  }, [
+    borrowerAccount,
+    issuerAccountPrivateKey,
+    issuerAccountPublicKey,
+    setSubmitTransactionIsClicked,
+    submitTransactionIsClicked,
+  ]);
 
   return null;
 };


### PR DESCRIPTION
I tried to make the component IssueNewAsset reusable passing it the asset as a prop and rendering the component two times, but the second transaction (coming from the second IssueNewAsset component) always failed.

TODO: Find a way to make IssueNewAsset.js reusable